### PR TITLE
Subtract tokens bridged to AVAX

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -5,6 +5,6 @@ type SystemState @entity {
   " NEWO contract address on ETH Mainnet "
   coinAddress: Bytes!
 
-  " Total circulating supply of NEWO "
-  circulatingSupply: BigDecimal!
+  " Total circulating supply of NEWO on Ethereum Mainnet "
+  ethCirculatingSupply: BigDecimal!
 }

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -28,8 +28,6 @@ import {
   tryNEWOTotalSupply,
 } from "./utils/readContract"
 
-// Contract events, each is called when its corresponding NEWO contract interaction is triggered
-
 export function handleApproval(event: Approval): void {
   updateSystemState(event)
 }
@@ -63,11 +61,11 @@ function updateSystemState(event: ethereum.Event): void {
   if (!systemState) {
     systemState = new SystemState("0")
     systemState.coinAddress = Bytes.fromByteArray(NEWO_TOKEN_ADDRESS)
-    systemState.circulatingSupply = BigDecimal.zero()
+    systemState.ethCirculatingSupply = BigDecimal.zero()
   }
 
   // Update values that change, for now just circulating supply
-  systemState.circulatingSupply = determineCirculatingSupply()
+  systemState.ethCirculatingSupply = determineCirculatingSupply()
   systemState.save()
 }
 

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -18,6 +18,7 @@ import {
   ONE_WAY_SWAP_ADDRESS,
   LOCKED_TOKEN_ADDRESS_LIST,
   VESTING_CONTRACTS_ADDRESS_LIST,
+  SYNAPSE_ADDRESS,
 } from "./utils/addresses"
 import {
   tryNEWOBalanceOf,
@@ -106,12 +107,16 @@ function determineCirculatingSupply(): BigDecimal {
   let safeBalance = tryNEWOBalanceOf(contract, GNOSIS_SAFE_ADDRESS)
   let oneWaySwapBalance = tryNEWOBalanceOf(contract, ONE_WAY_SWAP_ADDRESS)
 
+  // Synapse address (tokens here have been bridged to AVAX)
+  let synapseBalance = tryNEWOBalanceOf(contract, SYNAPSE_ADDRESS)
+
   let circulatingSupply = totalSupply
     .minus(totalLockedBalances)
     .minus(totalVestingBalances)
     .minus(lockedInLp)
     .minus(safeBalance)
     .minus(oneWaySwapBalance)
+    .minus(synapseBalance)
     .div(BigDecimal.fromString("1000000000000000000"))
 
   return circulatingSupply

--- a/src/utils/addresses.ts
+++ b/src/utils/addresses.ts
@@ -4,6 +4,7 @@ export let NEWO_TOKEN_ADDRESS = Address.fromString("0x98585dFc8d9e7D48F0b1aE47ce
 export let SLP_TOKEN_ADDRESS = Address.fromString("0xc08ED9a9ABEAbcC53875787573DC32Eee5E43513")
 export let GNOSIS_SAFE_ADDRESS = Address.fromString("0x4a848F44146Ca6D1D6AA34bcdF3C41093deF1761")
 export let ONE_WAY_SWAP_ADDRESS = Address.fromString("0xb3c60348A8f8eD8B260FD1966c9f2b740e6caedF")
+export let SYNAPSE_ADDRESS = Address.fromString("0x2796317b0fF8538F253012862c06787Adfb8cEb6")
 
 // Locked tokens addresses
 export let LOCKED_TOKEN_ADDRESS_LIST = mapStringsToAddresses([


### PR DESCRIPTION
These tokens are held 1:1 in Synapse's address. If we count them on ETH and on AVAX, we're double counting them, so we subtract them here. 

Also renamed circulatingSupply to ethCirculatingSupply for clarity. 